### PR TITLE
Feature trackball

### DIFF
--- a/src/ofxGrabCam.cpp
+++ b/src/ofxGrabCam.cpp
@@ -14,6 +14,7 @@ ofxGrabCam::ofxGrabCam(bool useMouseListeners) : initialised(true), mouseDown(fa
 	this->initialised = false;
 	this->mouseActions = true;
 	this->trackballRadius = 0.5f;
+	this->resetDown = 0;
 	
 	ofCamera::setNearClip(0.1);
 	addListeners();
@@ -242,8 +243,12 @@ void ofxGrabCam::mouseDragged(ofMouseEventArgs &args) {
 
 //--------------------------
 void ofxGrabCam::keyPressed(ofKeyEventArgs &args) {
-	if (args.key == 'r')
-		reset();
+	if (args.key == 'r') {
+		if (resetDown == 0)
+			resetDown = ofGetElapsedTimeMillis();
+		else if (ofGetElapsedTimeMillis() - resetDown > OFXGRABCAM_RESET_HOLD)
+			this->reset();
+	}
 	
 	if (args.key == 'h')
 		handDown = true;
@@ -257,6 +262,9 @@ void ofxGrabCam::keyPressed(ofKeyEventArgs &args) {
 void ofxGrabCam::keyReleased(ofKeyEventArgs &args) {
 	if (args.key == 'h')
 		handDown = false;
+	
+	if (args.key == 'r')
+		resetDown = 0;
 	
 	if (args.key == OF_KEY_ALT)
 		altDown = false;

--- a/src/ofxGrabCam.h
+++ b/src/ofxGrabCam.h
@@ -13,6 +13,7 @@
 #define OFXGRABCAM_SEARCH_WIDTH 1.0f
 #define OFXGRABCAM_SEARCH_MAX_ITERATIONS 100
 #define OFXGRABCAM_SEARCH_WINDINGS 10.0f
+#define OFXGRABCAM_RESET_HOLD 500 //ms
 
 class ofxGrabCam : public ofCamera {
 public:	
@@ -75,6 +76,11 @@ protected:
 	//
 	////
 	
+	
+	////
+	//interactions
+	int		resetDown;
+	////
 	
 	////
 	//view


### PR DESCRIPTION
@roymacdonald  - here i've changed the rotation to use a trackball mechanism rather than simple rotation. you'd need to disable `setFixUpwards` to get the proper peronality (i.e. press 'u' in the example)

could you check it out and see if it gives the action you wanted
i did some tests with 'arcball' maths, but it doesn't work well when you always start the rotation from the centre of the arcball, common issues are : 
1. Radius of arcball is too big (you always start the action in the centre, and must allow user to travel to opposite edge of screen)
2. It's impossible to get the z-axis rotations without destroying the rotation you already have

trackball is essentially the same maths, but in a finite difference model where mouse dx,dy are acting on start x, start y

possibility of a 'hold hotkey to roll'

also to @kylemcdonald - anything else i could improve on this?
